### PR TITLE
Rework home page layout with header and footer

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,22 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
 <head>
-    <style>
-        body {
-            background-image: url("/static/images/background.jpeg");
-            background-size: cover;
-            background-position: center;
-            /* Additional CSS properties for the body element */
-        }
-
-    </style>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Data Profusion</title>
     <link rel="stylesheet" type="text/css" href="/static/css/style.css" />
     <script type="text/javascript" src="/static/js/jquery.particleground.js"></script>
     <script type="text/javascript" src="/static/js/demo.js"></script>
 </head>
 
 <body>
-    <!--<p>Data Profusion</p>
-    <p>Business, Accounting, Technology, Security & Software Consulting</p> -->
+    <header>
+        <nav id="navbar">
+            <a href="#">Home</a>
+            <a href="#">About</a>
+            <a href="#">Contact</a>
+        </nav>
+        <div id="news-ticker"><marquee>Latest news goes here</marquee></div>
+        <div id="price-ticker"><marquee>BTC $00, ETH $00</marquee></div>
+    </header>
 
-    <div id="particles"></div>
-    <div id="intro"></div>
+    <main>
+        <div id="particles"></div>
+        <div id="intro">
+            <h1>Data Profusion</h1>
+            <p>Business, Accounting, Technology, Security &amp; Software Consulting</p>
+        </div>
+    </main>
+
+    <footer>
+        <div class="footer-ticker"><marquee>Additional information scrolling here</marquee></div>
+        <nav class="footer-nav">
+            <a href="#privacy">Privacy</a> |
+            <a href="#terms">Terms</a>
+        </nav>
+    </footer>
 </body>
+</html>
+

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -56,8 +56,8 @@ table {
 
 html, body {
   width: 100%;
-  height: 100%;
-  overflow: hidden;
+  min-height: 100%;
+  overflow-x: hidden;
 }
 
 body {
@@ -74,18 +74,61 @@ body {
 }
 
 #particles {
+  position: fixed;
+  top: 0;
+  left: 0;
   width: 100%;
   height: 100%;
   overflow: hidden;
+  z-index: -1;
 }
 
 #intro {
-  position: absolute;
+  position: relative;
   left: 0;
-  top: 50%;
-  padding: 0 20px;
+  padding: 40px 20px;
   width: 100%;
   text-align: center;
+}
+
+header, footer {
+  width: 100%;
+}
+
+#navbar, #news-ticker, #price-ticker, .footer-ticker, .footer-nav {
+  background: rgba(0, 0, 0, 0.6);
+  padding: 10px;
+  color: #fff;
+}
+
+#navbar a, .footer-nav a {
+  color: #fff;
+  margin: 0 10px;
+  text-decoration: none;
+}
+
+#navbar a:hover, .footer-nav a:hover {
+  color: #dea518;
+}
+
+header {
+  position: sticky;
+  top: 0;
+  z-index: 1000;
+}
+
+main {
+  padding-top: 20px;
+}
+
+.footer-nav {
+  text-align: center;
+}
+
+.footer-ticker marquee,
+#news-ticker marquee,
+#price-ticker marquee {
+  white-space: nowrap;
 }
 h1 {
   text-transform: uppercase;

--- a/static/js/demo.js
+++ b/static/js/demo.js
@@ -8,8 +8,6 @@ document.addEventListener('DOMContentLoaded', function () {
     dotColor: '#dea518',
     lineColor: '#e3ebeb'
   });
-  var intro = document.getElementById('intro');
-  intro.style.marginTop = - intro.offsetHeight / 2 + 'px';
 }, false);
 
 


### PR DESCRIPTION
## Summary
- Add top navigation bar with news and price tickers below it
- Introduce footer section with a scrolling ticker and navigation links
- Adjust CSS and JavaScript to support new layout and keep main content visible

## Testing
- `python run_tests.py unit` *(fails: NameError: name 'Mock' is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_689eb66b5cb08326b9c274767102ccb9