### PR TITLE
style: add spacing around tickers and footer

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -6,7 +6,7 @@
     backdrop-filter: blur(10px);
     border: 2px solid rgba(255, 255, 255, 0.2);
     border-radius: 15px;
-    margin: 0;
+    margin: 0 0 1rem 0;
     overflow: hidden;
     position: relative;
     opacity: 0;

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -34,7 +34,7 @@
             flex-direction: column;
             align-items: center;
             justify-content: center;
-            padding: 120px 5px 80px 5px;
+            padding: 170px 5px 80px 5px;
             box-sizing: border-box;
         }
 
@@ -82,7 +82,7 @@
             backdrop-filter: blur(10px);
             border: 2px solid rgba(255, 255, 255, 0.2);
             border-radius: 15px;
-            margin-bottom: 0rem;
+            margin-bottom: 1rem;
             overflow: hidden;
             position: relative;
             opacity: 0;
@@ -98,7 +98,7 @@
             backdrop-filter: blur(10px);
             border: 2px solid rgba(255, 255, 255, 0.2);
             border-radius: 15px;
-            margin-bottom: 0rem;
+            margin-bottom: 1rem;
             overflow: hidden;
             position: relative;
             opacity: 0;
@@ -226,7 +226,7 @@
 
         @media (max-width: 768px) {
             .main-content {
-                padding: 150px 5px 80px 5px;
+                padding: 200px 5px 80px 5px;
             }
             
             .nav-brand {
@@ -291,6 +291,7 @@
             border-radius: 15px;
             opacity: 0;
             animation: fadeIn 1.5s ease-out 1s forwards;
+            margin-bottom: 1rem;
         }
 
         .nav-content {
@@ -350,7 +351,7 @@
             backdrop-filter: blur(10px);
             border: 2px solid rgba(255, 255, 255, 0.2);
             border-radius: 15px;
-            margin-bottom: 0.5rem;
+            margin-bottom: 1rem;
             overflow: hidden;
             position: relative;
             opacity: 0;


### PR DESCRIPTION
## Summary
- add bottom margins to nav bar, news ticker, and price ticker for even spacing
- increase main content padding to accommodate header spacing and adjust mobile layout
- space footer ticker away from body content

## Testing
- `python run_tests.py unit`


------
https://chatgpt.com/codex/tasks/task_e_689ffb041a488326863063736bc14fc7