### PR TITLE
Refactor home page to use base layout

### DIFF
--- a/app/static/css/home.css
+++ b/app/static/css/home.css
@@ -1,0 +1,236 @@
+body {
+    background-image: url("../images/background.jpeg");
+    background-size: cover;
+    background-position: center;
+    background-attachment: fixed;
+    margin: 0;
+    padding: 0;
+    font-family: 'Arial', sans-serif;
+    min-height: 100vh;
+    overflow-x: hidden;
+}
+
+#particles {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    z-index: 1;
+}
+
+.main-content {
+    position: relative;
+    z-index: 2;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    padding: 200px 5px 80px 5px;
+    box-sizing: border-box;
+    min-height: calc(100vh - 100px);
+    margin: 2rem auto;
+}
+
+@keyframes fadeInUp {
+    from {
+        opacity: 0;
+        transform: translateY(30px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+.news-ticker {
+    width: 100%;
+    height: 45px;
+    background: rgba(0, 0, 0, 0.7);
+    backdrop-filter: blur(10px);
+    border: 2px solid rgba(255, 255, 255, 0.2);
+    border-radius: 15px;
+    margin-bottom: 0rem;
+    overflow: hidden;
+    position: relative;
+    opacity: 0;
+    animation: fadeIn 1.5s ease-out 1s forwards;
+    z-index: 2;
+}
+
+.news-ticker .ticker-content {
+    display: flex;
+    align-items: center;
+    height: 100%;
+    animation: scroll-left 25s linear infinite;
+    white-space: nowrap;
+}
+
+.news-ticker .ticker-content:hover {
+    animation-play-state: paused;
+}
+
+@keyframes scroll-left {
+    0% { transform: translateX(100%); }
+    100% { transform: translateX(-100%); }
+}
+
+.news-ticker .ticker-item {
+    display: inline-flex;
+    align-items: center;
+    padding: 0 2rem;
+    color: #228B22;
+    text-decoration: none;
+    font-weight: bold;
+    font-size: 0.9rem;
+    transition: color 0.3s ease;
+    cursor: pointer;
+    border-right: 1px solid rgba(34, 139, 34, 0.3);
+    height: 100%;
+}
+
+.news-ticker .ticker-item:hover {
+    color: #32CD32;
+}
+
+.news-ticker .ticker-item:last-child {
+    border-right: none;
+}
+
+.chart-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    gap: 2rem;
+    max-width: 1000px;
+    width: 100%;
+    opacity: 0;
+    animation: fadeIn 1.5s ease-out 1.5s forwards;
+}
+
+.chart-link {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    text-decoration: none;
+    background: rgba(255, 255, 255, 0.1);
+    backdrop-filter: blur(10px);
+    border: 2px solid rgba(255, 255, 255, 0.2);
+    border-radius: 15px;
+    padding: 2rem;
+    transition: all 0.3s ease;
+    color: #228B22;
+    font-weight: bold;
+}
+
+.chart-link:hover {
+    transform: translateY(-5px);
+    background: rgba(0, 0, 0, 0.7);
+    border-color: #228B22;
+    box-shadow: 0 10px 25px rgba(34, 139, 34, 0.3);
+}
+
+.chart-icon {
+    width: 80px;
+    height: 80px;
+    background: #228B22;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 1.5rem;
+    font-weight: bold;
+    color: white;
+    margin-bottom: 1rem;
+    transition: all 0.3s ease;
+}
+
+.chart-link:hover .chart-icon {
+    background: #32CD32;
+    transform: scale(1.1);
+}
+
+.chart-title {
+    font-size: 1.1rem;
+    text-align: center;
+    transition: all 0.3s ease;
+}
+
+.chart-link:hover .chart-title {
+    font-size: 1.1rem;
+    text-decoration: underline;
+    color: #32CD32;
+}
+
+@media (max-width: 768px) {
+    .main-content {
+        padding: 220px 5px 60px 5px;
+    }
+
+    .news-ticker {
+        height: 50px;
+    }
+
+    .news-ticker .ticker-item {
+        font-size: 0.8rem;
+        padding: 0 1.5rem;
+    }
+
+    .chart-grid {
+        grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+        gap: 1.5rem;
+        max-width: 600px;
+    }
+
+    .chart-link {
+        padding: 1.5rem;
+    }
+
+    .chart-icon {
+        width: 60px;
+        height: 60px;
+        font-size: 1.2rem;
+    }
+}
+
+.top-section {
+    width: 100%;
+    padding-bottom: 1rem;
+}
+
+.footer {
+    width: 100%;
+    margin-top: 3rem;
+    text-align: center;
+    padding: 1rem 0;
+}
+
+.footer-ticker {
+    width: 100%;
+    height: 25px;
+    background: rgba(0, 0, 0, 0.7);
+    backdrop-filter: blur(10px);
+    border: 2px solid rgba(255, 255, 255, 0.2);
+    border-radius: 15px;
+    margin-bottom: 0.5rem;
+    overflow: hidden;
+    position: relative;
+    opacity: 0;
+    animation: fadeIn 1.5s ease-out 1s forwards;
+}
+
+.footer-nav {
+    display: flex;
+    justify-content: center;
+}
+
+.footer-nav a {
+    color: #39FF14;
+    text-decoration: none;
+    font-weight: bold;
+    padding: 0.5rem 1rem;
+    transition: color 0.3s ease;
+}
+
+.footer-nav a:hover {
+    color: #00ff88;
+}

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -1,522 +1,121 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Data Profusion - Charts For Life</title>
-    
-    <style>
-        body {
-            background-image: url("{{ url_for('static', filename='images/background.jpeg') }}");
-            background-size: cover;
-            background-position: center;
-            background-attachment: fixed;
-            margin: 0;
-            padding: 0;
-            font-family: 'Arial', sans-serif;
-            min-height: 100vh;
-            overflow-x: hidden;
-        }
+{% extends "layout.html" %}
 
-        #particles {
-            position: fixed;
-            top: 0;
-            left: 0;
-            width: 100%;
-            height: 100%;
-            z-index: 1;
-        }
+{% block head %}
+<link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}">
+<link rel="stylesheet" href="{{ url_for('static', filename='css/home.css') }}">
+<link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@700&display=swap" rel="stylesheet">
+<link rel="icon" type="image/svg+xml" href="{{ url_for('static', filename='images/favicon.svg') }}">
+<link rel="alternate icon" href="{{ url_for('static', filename='images/favicon.ico') }}">
+<link rel="apple-touch-icon" href="{{ url_for('static', filename='images/apple-touch-icon.png') }}">
+{% endblock %}
 
-        .main-content {
-            position: relative;
-            z-index: 2;
-            display: flex;
-            flex-direction: column;
-            align-items: center;
-            justify-content: center;
-            padding: 200px 5px 80px 5px; /* Increase top padding to account for fixed header */
-            box-sizing: border-box;
-            min-height: calc(100vh - 100px); /* Subtract approximate header + footer height */
-            margin: 2rem auto; /* Add horizontal auto margins */
-        }
-
-        .nav-brand {
-            font-family: 'Impact', 'Arial Black', sans-serif;
-            font-size: 1.8rem;
-            font-weight: bold;
-            color: #39FF14;
-            text-transform: uppercase;
-            letter-spacing: 2px;
-            transform: skew(-15deg);
-            text-shadow:
-                -1px -1px 0 rgba(0, 0, 0, 0.7),
-                1px -1px 0 rgba(0, 0, 0, 0.7),
-                -1px 1px 0 rgba(0, 0, 0, 0.7),
-                1px 1px 0 rgba(0, 0, 0, 0.7),
-                0 0 5px #39FF14,
-                0 0 10px #39FF14,
-                0 0 20px #39FF14,
-                0 0 40px #39FF14,
-                3px 3px 5px rgba(0, 0, 0, 0.8);
-            background: linear-gradient(45deg, #39FF14, #00ff88);
-            -webkit-background-clip: text;
-            background-clip: text;
-            -webkit-text-fill-color: transparent;
-            text-decoration: none;
-        }
-
-        @keyframes fadeInUp {
-            from {
-                opacity: 0;
-                transform: translateY(30px);
-            }
-            to {
-                opacity: 1;
-                transform: translateY(0);
-            }
-        }
-
-        .news-ticker {
-            width: 100%;
-            /* max-width: 1000px; */
-            height: 45px;
-            background: rgba(0, 0, 0, 0.7);
-            backdrop-filter: blur(10px);
-            border: 2px solid rgba(255, 255, 255, 0.2);
-            border-radius: 15px;
-            margin-bottom: 0rem;
-            overflow: hidden;
-            position: relative;
-            opacity: 0;
-            animation: fadeIn 1.5s ease-out 1s forwards;
-            z-index: 2; /*puts the news ticket above particles*/
-        }
-
-        .price-ticker {
-            width: 100%;
-            /* max-width: 1000px; */
-            height: 25px;
-            background: rgba(0, 0, 0, 0.7);
-            backdrop-filter: blur(10px);
-            border: 2px solid rgba(255, 255, 255, 0.2);
-            border-radius: 15px;
-            margin-bottom: 0rem;
-            overflow: hidden;
-            position: relative;
-            opacity: 0;
-            animation: fadeIn 1.5s ease-out 1s forwards;
-            z-index: 2; /*puts the news ticket above particles*/
-        }
-
-
-        .ticker-content {
-            display: flex;
-            align-items: center;
-            height: 100%;
-            animation: scroll-left 25s linear infinite;
-            white-space: nowrap;
-        }
-
-        .price-content {
-            display: flex;
-            align-items: center;
-            height: 100%;
-            animation: scroll-left 12s linear infinite;
-            white-space: nowrap;
-        }
-
-
-        .ticker-content:hover {
-            animation-play-state: paused;
-        }
-
-        @keyframes scroll-left {
-            0% { transform: translateX(100%); }
-            100% { transform: translateX(-100%); }
-        }
-
-        .ticker-item {
-            display: inline-flex;
-            align-items: center;
-            padding: 0 2rem;
-            color: #228B22;
-            text-decoration: none;
-            font-weight: bold;
-            font-size: 0.9rem;
-            transition: color 0.3s ease;
-            cursor: pointer;
-            border-right: 1px solid rgba(34, 139, 34, 0.3);
-            height: 100%;
-        }
-
-        .ticker-item:hover {
-            color: #32CD32;
-        }
-
-        .ticker-item:last-child {
-            border-right: none;
-        }
-
-        .chart-grid {
-            display: grid;
-            grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-            gap: 2rem;
-            max-width: 1000px;
-            width: 100%;
-            opacity: 0;
-            animation: fadeIn 1.5s ease-out 1.5s forwards;
-        }
-
-        @keyframes fadeIn {
-            from { opacity: 0; }
-            to { opacity: 1; }
-        }
-
-        .chart-link {
-            display: flex;
-            flex-direction: column;
-            align-items: center;
-            text-decoration: none;
-            background: rgba(255, 255, 255, 0.1);
-            backdrop-filter: blur(10px);
-            border: 2px solid rgba(255, 255, 255, 0.2);
-            border-radius: 15px;
-            padding: 2rem;
-            transition: all 0.3s ease;
-            color: #228B22;
-            font-weight: bold;
-        }
-
-        .chart-link:hover {
-            transform: translateY(-5px);
-            background: rgba(0, 0, 0, 0.7);
-            border-color: #228B22;
-            box-shadow: 0 10px 25px rgba(34, 139, 34, 0.3);
-        }
-
-        .chart-icon {
-            width: 80px;
-            height: 80px;
-            background: #228B22;
-            border-radius: 50%;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            font-size: 1.5rem;
-            font-weight: bold;
-            color: white;
-            margin-bottom: 1rem;
-            transition: all 0.3s ease;
-        }
-
-        .chart-link:hover .chart-icon {
-            background: #32CD32;
-            transform: scale(1.1);
-        }
-
-        .chart-title {
-            font-size: 1.1rem;
-            text-align: center;
-            transition: all 0.3s ease;
-        }
-
-        .chart-link:hover .chart-title {
-            font-size: 1.1rem;
-            text-decoration: underline;
-            color: #32CD32;
-        }
-
-        @media (max-width: 768px) {
-            .main-content {
-                padding: 220px 5px 60px 5px; /* Adjust padding for mobile */
-            }
-            
-            .nav-brand {
-                font-size: 1.5rem;
-                margin-bottom: 0.5rem;
-            }
-            
-            .news-ticker {
-                height: 50px;
-                /* max-width: 600px; */
-            }
-            
-            .ticker-item {
-                font-size: 0.8rem;
-                padding: 0 1.5rem;
-            }
-            
-            .chart-grid {
-                grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
-                gap: 1.5rem;
-                max-width: 600px;
-            }
-            
-            .chart-link {
-                padding: 1.5rem;
-            }
-            
-            .chart-icon {
-                width: 60px;
-                height: 60px;
-                font-size: 1.2rem;
-            }
-            
-            .nav-content {
-                padding: 0 1rem;
-                flex-direction: column;
-                align-items: center;
-            }
-            
-            .nav-item {
-                padding: 0.5rem 0.8rem;
-                margin: 0 0.2rem;
-                font-size: 0.9rem;
-            }
-        }
-
-        .top-section {
-            position: fixed;
-            top: 0;
-            left: 0;
-            width: 100%;
-            z-index: 3;
-            padding-bottom: 1rem; /* Add padding below the price ticker */
-        }
-
-        .nav-bar {
-            position: relative;
-            width: 100%;
-            padding: 1rem 0;
-            background: rgba(0, 0, 0, 0.7);
-            backdrop-filter: blur(10px);
-            border: 2px solid rgba(255, 255, 255, 0.2);
-            border-radius: 15px;
-            opacity: 0;
-            animation: fadeIn 1.5s ease-out 1s forwards;
-        }
-
-        .nav-content {
-            display: flex;
-            justify-content: space-between;
-            align-items: center;
-            flex-wrap: wrap;
-            padding: 0 1rem;
-        }
-
-        .nav-links {
-            display: flex;
-            justify-content: center;
-            flex-wrap: wrap;
-        }
-
-        .nav-item {
-            color: #39FF14;
-            text-decoration: none;
-            font-weight: bold;
-            padding: 0.5rem 1rem;
-            transition: color 0.3s ease;
-            margin: 0 0.5rem;
-        }
-
-        .nav-item:hover {
-            color: #00ff88;
-            text-decoration: underline;
-            text-decoration-color: #00ff88;
-        }
-
-        .active {
-            color: #00ff88;
-            position: relative;
-        }
-
-        .active::after {
-            content: '';
-            position: absolute;
-            width: 100%;
-            height: 2px;
-            bottom: -5px;
-            left: 0;
-            background: linear-gradient(90deg, transparent, #00ff88, transparent);
-        }
-
-        .footer {
-            width: 100%;
-            margin-top: 3rem; /* Increase space above footer */
-            text-align: center;
-            padding: 1rem 0; /* Add padding around footer content */
-        }
-
-        .footer-ticker {
-            width: 100%;
-            height: 25px;
-            background: rgba(0, 0, 0, 0.7);
-            backdrop-filter: blur(10px);
-            border: 2px solid rgba(255, 255, 255, 0.2);
-            border-radius: 15px;
-            margin-bottom: 0.5rem;
-            overflow: hidden;
-            position: relative;
-            opacity: 0;
-            animation: fadeIn 1.5s ease-out 1s forwards;
-        }
-
-        .footer-nav {
-            display: flex;
-            justify-content: center;
-        }
-
-        .footer-nav a {
-            color: #39FF14;
-            text-decoration: none;
-            font-weight: bold;
-            padding: 0.5rem 1rem;
-            transition: color 0.3s ease;
-        }
-
-        .footer-nav a:hover {
-            color: #00ff88;
-        }
-    </style>
-    
-    <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='css/style.css') }}" />
-    <!-- Custom Fonts -->
-    <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@700&display=swap" rel="stylesheet">
-    <!-- Favicon -->
-    <link rel="icon" type="image/svg+xml" href="{{ url_for('static', filename='images/favicon.svg') }}">
-    <!-- Fallback favicon for browsers that don't support SVG -->
-    <link rel="alternate icon" href="{{ url_for('static', filename='images/favicon.ico') }}">
-    <!-- For iOS devices -->
-    <link rel="apple-touch-icon" href="{{ url_for('static', filename='images/apple-touch-icon.png') }}">
-    <!-- Price Ticker Script -->
-    <script src="{{ url_for('static', filename='js/price-ticker.js') }}" defer></script>
-</head>
-
-<body>
-    <div class="top-section">
-        <nav class="nav-bar">
-            <div class="nav-content">
-                <a href="{{ url_for('index') }}" class="nav-brand">Data Profusion</a>
-                <div class="nav-links">
-                    <a href="{{ url_for('index') }}" class="nav-item {{ 'active' if active_page == 'home' }}">Home</a>
-                    <a href="{{ url_for('charts') }}" class="nav-item {{ 'active' if active_page == 'charts' }}">Charts</a>
-                    <a href="{{ url_for('news') }}" class="nav-item {{ 'active' if active_page == 'news' }}">News</a>
-                    <a href="{{ url_for('about') }}" class="nav-item {{ 'active' if active_page == 'about' }}">About</a>
-                    <a href="{{ url_for('contact') }}" class="nav-item {{ 'active' if active_page == 'contact' }}">Contact</a>
-                </div>
-            </div>
-        </nav>
-        <div class="news-ticker">
-            <div class="ticker-content">
-                <a href="#" class="ticker-item" onclick="window.open('https://example.com', '_blank'); return false;">📈 Fed Raises Interest Rates by 0.25%</a>
-                <a href="#" class="ticker-item" onclick="window.open('https://example.com', '_blank'); return false;">💼 Unemployment Drops to 3.7%</a>
-                <a href="#" class="ticker-item" onclick="window.open('https://example.com', '_blank'); return false;">🏦 Banking Sector Shows Strong Q3 Results</a>
-                <a href="#" class="ticker-item" onclick="window.open('https://example.com', '_blank'); return false;">📊 GDP Growth Exceeds Expectations</a>
-                <a href="#" class="ticker-item" onclick="window.open('https://example.com', '_blank'); return false;">💰 Inflation Rate Stabilizes at 2.1%</a>
-                <a href="#" class="ticker-item" onclick="window.open('https://example.com', '_blank'); return false;">🌍 Global Trade Volume Increases</a>
-                <a href="#" class="ticker-item" onclick="window.open('https://example.com', '_blank'); return false;">⚡ Energy Prices Show Volatility</a>
-                <a href="#" class="ticker-item" onclick="window.open('https://example.com', '_blank'); return false;">🏭 Manufacturing Index Rises</a>
-            </div>
-        </div>
-        <div class="price-ticker">
-            <div class="ticker-content">
-                <span class="ticker-item crypto">
-                    <span class="symbol">BTC</span>
-                    <span class="price">$43,215.67</span>
-                    <span class="change positive">+2.45%</span>
-                </span>
-                <span class="ticker-item stock">
-                    <span class="symbol">AAPL</span>
-                    <span class="price">$189.84</span>
-                    <span class="change negative">-0.73%</span>
-                </span>
-                <span class="ticker-item crypto">
-                    <span class="symbol">ETH</span>
-                    <span class="price">$2,245.12</span>
-                    <span class="change positive">+3.21%</span>
-                </span>
-                <span class="ticker-item stock">
-                    <span class="symbol">MSFT</span>
-                    <span class="price">$376.95</span>
-                    <span class="change positive">+1.25%</span>
-                </span>
-                <span class="ticker-item crypto">
-                    <span class="symbol">SOL</span>
-                    <span class="price">$98.45</span>
-                    <span class="change positive">+5.67%</span>
-                </span>
-                <span class="ticker-item stock">
-                    <span class="symbol">NVDA</span>
-                    <span class="price">$457.82</span>
-                    <span class="change positive">+2.89%</span>
-                </span>
-            </div>
-        </div>
+{% block content %}
+<div class="top-section">
+  <div class="news-ticker">
+    <div class="ticker-content">
+      <a href="#" class="ticker-item" onclick="window.open('https://example.com', '_blank'); return false;">📈 Fed Raises Interest Rates by 0.25%</a>
+      <a href="#" class="ticker-item" onclick="window.open('https://example.com', '_blank'); return false;">💼 Unemployment Drops to 3.7%</a>
+      <a href="#" class="ticker-item" onclick="window.open('https://example.com', '_blank'); return false;">🏦 Banking Sector Shows Strong Q3 Results</a>
+      <a href="#" class="ticker-item" onclick="window.open('https://example.com', '_blank'); return false;">📊 GDP Growth Exceeds Expectations</a>
+      <a href="#" class="ticker-item" onclick="window.open('https://example.com', '_blank'); return false;">💰 Inflation Rate Stabilizes at 2.1%</a>
+      <a href="#" class="ticker-item" onclick="window.open('https://example.com', '_blank'); return false;">🌍 Global Trade Volume Increases</a>
+      <a href="#" class="ticker-item" onclick="window.open('https://example.com', '_blank'); return false;">⚡ Energy Prices Show Volatility</a>
+      <a href="#" class="ticker-item" onclick="window.open('https://example.com', '_blank'); return false;">🏭 Manufacturing Index Rises</a>
     </div>
-
-    <div id="particles"></div>
-
-    <div class="main-content">
-        <div class="chart-grid">
-            <a href="{{ url_for('charts') }}" target="_blank" class="chart-link">
-                <div class="chart-icon">GDP</div>
-                <div class="chart-title">Economic Growth</div>
-            </a>
-
-            <a href="#" class="chart-link" onclick="alert('Coming Soon!')">
-                <div class="chart-icon">JOBS</div>
-                <div class="chart-title">Employment Stats</div>
-            </a>
-
-            <a href="#" class="chart-link" onclick="alert('Coming Soon!')">
-                <div class="chart-icon">$</div>
-                <div class="chart-title">Market Data</div>
-            </a>
-
-            <a href="#" class="chart-link" onclick="alert('Coming Soon!')">
-                <div class="chart-icon">📊</div>
-                <div class="chart-title">Trade Balance</div>
-            </a>
-
-            <a href="#" class="chart-link" onclick="alert('Coming Soon!')">
-                <div class="chart-icon">🏦</div>
-                <div class="chart-title">Banking Sector</div>
-            </a>
-
-            <a href="#" class="chart-link" onclick="alert('Coming Soon!')">
-                <div class="chart-icon">📈</div>
-                <div class="chart-title">Stock Indices</div>
-            </a>
-
-            <a href="#" class="chart-link" onclick="alert('Coming Soon!')">
-                <div class="chart-icon">₿</div>
-                <div class="chart-title">Cryptocurrency</div>
-            </a>
-
-            <a href="#" class="chart-link" onclick="alert('Coming Soon!')">
-                <div class="chart-icon">🤖</div>
-                <div class="chart-title">AI</div>
-            </a>
-
-        </div>
+  </div>
+  <div class="price-ticker">
+    <div class="ticker-content">
+      <span class="ticker-item crypto">
+        <span class="symbol">BTC</span>
+        <span class="price">$43,215.67</span>
+        <span class="change positive">+2.45%</span>
+      </span>
+      <span class="ticker-item stock">
+        <span class="symbol">AAPL</span>
+        <span class="price">$189.84</span>
+        <span class="change negative">-0.73%</span>
+      </span>
+      <span class="ticker-item crypto">
+        <span class="symbol">ETH</span>
+        <span class="price">$2,245.12</span>
+        <span class="change positive">+3.21%</span>
+      </span>
+      <span class="ticker-item stock">
+        <span class="symbol">MSFT</span>
+        <span class="price">$376.95</span>
+        <span class="change positive">+1.25%</span>
+      </span>
+      <span class="ticker-item crypto">
+        <span class="symbol">SOL</span>
+        <span class="price">$98.45</span>
+        <span class="change positive">+5.67%</span>
+      </span>
+      <span class="ticker-item stock">
+        <span class="symbol">NVDA</span>
+        <span class="price">$457.82</span>
+        <span class="change positive">+2.89%</span>
+      </span>
     </div>
+  </div>
+</div>
 
-    <footer class="footer">
-        <div class="footer-ticker">
-            <div class="ticker-content">
-                <span class="ticker-item">© 2024 Data Profusion</span>
-                <span class="ticker-item">For educational use only</span>
-                <span class="ticker-item">Contact us for more info</span>
-            </div>
-        </div>
-        <nav class="footer-nav">
-            <a href="#privacy">Privacy</a>
-            <a href="#terms">Terms</a>
-        </nav>
-    </footer>
+<div id="particles"></div>
 
-    <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
-    <script type="text/javascript" src="{{ url_for('static', filename='js/jquery.particleground.js') }}"></script>
-    <script type="text/javascript" src="{{ url_for('static', filename='js/demo.js') }}"></script>
-</body>
-</html>
+<div class="main-content">
+  <div class="chart-grid">
+    <a href="{{ url_for('charts') }}" target="_blank" class="chart-link">
+      <div class="chart-icon">GDP</div>
+      <div class="chart-title">Economic Growth</div>
+    </a>
+    <a href="#" class="chart-link" onclick="alert('Coming Soon!')">
+      <div class="chart-icon">JOBS</div>
+      <div class="chart-title">Employment Stats</div>
+    </a>
+    <a href="#" class="chart-link" onclick="alert('Coming Soon!')">
+      <div class="chart-icon">$</div>
+      <div class="chart-title">Market Data</div>
+    </a>
+    <a href="#" class="chart-link" onclick="alert('Coming Soon!')">
+      <div class="chart-icon">📊</div>
+      <div class="chart-title">Trade Balance</div>
+    </a>
+    <a href="#" class="chart-link" onclick="alert('Coming Soon!')">
+      <div class="chart-icon">🏦</div>
+      <div class="chart-title">Banking Sector</div>
+    </a>
+    <a href="#" class="chart-link" onclick="alert('Coming Soon!')">
+      <div class="chart-icon">📈</div>
+      <div class="chart-title">Stock Indices</div>
+    </a>
+    <a href="#" class="chart-link" onclick="alert('Coming Soon!')">
+      <div class="chart-icon">₿</div>
+      <div class="chart-title">Cryptocurrency</div>
+    </a>
+    <a href="#" class="chart-link" onclick="alert('Coming Soon!')">
+      <div class="chart-icon">🤖</div>
+      <div class="chart-title">AI</div>
+    </a>
+  </div>
+</div>
+
+<footer class="footer">
+  <div class="footer-ticker">
+    <div class="ticker-content">
+      <span class="ticker-item">© 2024 Data Profusion</span>
+      <span class="ticker-item">For educational use only</span>
+      <span class="ticker-item">Contact us for more info</span>
+    </div>
+  </div>
+  <nav class="footer-nav">
+    <a href="#privacy">Privacy</a>
+    <a href="#terms">Terms</a>
+  </nav>
+</footer>
+{% endblock %}
+
+{% block scripts %}
+<script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+<script type="text/javascript" src="{{ url_for('static', filename='js/jquery.particleground.js') }}"></script>
+<script type="text/javascript" src="{{ url_for('static', filename='js/demo.js') }}"></script>
+<script src="{{ url_for('static', filename='js/price-ticker.js') }}" defer></script>
+{% endblock %}

--- a/app/templates/layout.html
+++ b/app/templates/layout.html
@@ -18,6 +18,7 @@
         margin: 40px;
       }
     </style>
+    {% block head %}{% endblock %}
   </head>
   <body>
     <nav class="nav-bar">
@@ -33,5 +34,6 @@
       </div>
     </nav>
     {% block content %}{% endblock %}
+    {% block scripts %}{% endblock %}
   </body>
 </html>

--- a/app/templates/layout.html
+++ b/app/templates/layout.html
@@ -13,6 +13,7 @@
       href="https://cdnjs.cloudflare.com/ajax/libs/skeleton/2.0.4/skeleton.min.css"
     />
     <link rel="stylesheet" href="{{ url_for('static', filename='css/nav.css') }}" />
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}" />
     <style>
       body {
         margin: 40px;


### PR DESCRIPTION
## Summary
- Convert index.html to extend the shared layout and move page-specific HTML into a content block
- Add head and scripts blocks in layout.html and relocate home page styles into a dedicated static file
- Keep navigation highlighting via active_page and ensure scripts load only on the home page

## Testing
- `python run_tests.py unit`

------
https://chatgpt.com/codex/tasks/task_e_68a01678f2608326a66930e8eb1dc4d5