### PR TITLE
Add charts listing page and adjust navigation

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -20,7 +20,8 @@ def init_routes(app):
 
     @app.route("/charts")
     def charts():
-        return redirect("/dash/")
+        """Render a list of available Dash charts."""
+        return render_template("charts.html", active_page="charts")
 
     @app.route("/news")
     def news():

--- a/app/templates/charts.html
+++ b/app/templates/charts.html
@@ -1,0 +1,9 @@
+{% extends "layout.html" %}
+{% block content %}
+<div class="main-content">
+    <h1>Available Charts</h1>
+    <ul>
+        <li><a href="/dash/" target="_blank">Sample GDP Growth</a></li>
+    </ul>
+</div>
+{% endblock %}

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -458,7 +458,7 @@
 
     <div class="main-content">
         <div class="chart-grid">
-            <a href="{{ url_for('charts') }}" target="_blank" class="chart-link">
+            <a href="/dash/" target="_blank" class="chart-link">
                 <div class="chart-icon">GDP</div>
                 <div class="chart-title">Economic Growth</div>
             </a>


### PR DESCRIPTION
## Summary
- serve a template at `/charts` that lists available Dash charts
- keep homepage chart grid linking directly to `/dash/` so charts can open in a new tab

## Testing
- `python run_tests.py unit`


------
https://chatgpt.com/codex/tasks/task_e_68a0e25adf7483269f59edc154812360