### PR TITLE
Add Docker and docker-compose setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM python:3.13-slim
+
+# Set work directory
+WORKDIR /app
+
+# Install dependencies
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy application code
+COPY . .
+
+# Expose port for the web service
+EXPOSE 8000
+
+# Run the gunicorn server
+CMD ["gunicorn", "-b", "0.0.0.0:8000", "app:create_app()"]

--- a/README.md
+++ b/README.md
@@ -67,6 +67,31 @@ or the official Python installer for your operating system.
 6. **Visit your Dash application.**  Once the server is running, open
    `http://127.0.0.1:5000/dash/` in your browser to see the sample chart.
 
+## Docker
+
+You can build and run the application inside a Docker container.
+
+### Build the image
+
+```bash
+docker build -t economy-charts .
+```
+
+### Run the container
+
+```bash
+docker run -p 8000:8000 economy-charts
+```
+
+### Using docker-compose
+
+The repository includes a `docker-compose.yml` that starts the web application
+along with a small Redis cache. To build and run all services:
+
+```bash
+docker compose up --build
+```
+
 ## Testing
 
 This project includes a comprehensive test suite to ensure reliability and data quality.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+version: '3.9'
+services:
+  web:
+    build: .
+    command: gunicorn -b 0.0.0.0:8000 "app:create_app()"
+    ports:
+      - "8000:8000"
+    depends_on:
+      - redis
+  redis:
+    image: redis:7-alpine


### PR DESCRIPTION
## Summary
- add Dockerfile that installs dependencies and runs gunicorn on port 8000
- define docker-compose.yml with web and Redis services
- document Docker build and run commands in README

## Testing
- `python run_tests.py unit`


------
https://chatgpt.com/codex/tasks/task_e_68a5557c5e908326aef2b977f84d7a63