### PR TITLE
Use environment variables for configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,8 @@
+# Flask configuration
+FLASK_CONFIG=development
+
+# API keys
+FRED_API_KEY=your-fred-api-key
+COINMARKETCAP_API_KEY=your-cmc-api-key
+COINGECKO_API_KEY=your-coingecko-api-key
+

--- a/CONFIG_SETUP.md
+++ b/CONFIG_SETUP.md
@@ -64,14 +64,18 @@ The configuration is stored in `config/secrets.json` (automatically created):
 - **URL**: https://www.coingecko.com/en/api
 - **Required for**: Alternative cryptocurrency data source
 
-## Environment Variables (Alternative)
+## Environment Variables
 
-You can also set API keys via environment variables:
+Configuration values can also be supplied through environment variables or a `.env` file. Set the following variables:
 
 ```bash
-export FRED_API_KEY="your-fred-key"
-export COINMARKETCAP_API_KEY="your-cmc-key"
-export COINGECKO_API_KEY="your-gecko-key"
+FRED_API_KEY="your-fred-key"
+COINMARKETCAP_API_KEY="your-cmc-key"
+COINGECKO_API_KEY="your-gecko-key"
+FLASK_CONFIG="development"
 ```
 
-Environment variables take precedence over the config file.
+- `FRED_API_KEY` – required for accessing economic data from FRED
+- `FLASK_CONFIG` – selects the Flask configuration (e.g., `development`, `production`)
+
+Environment variables take precedence over the config file. An `.env.example` file is provided as a template.

--- a/app/config/secrets.py
+++ b/app/config/secrets.py
@@ -130,7 +130,7 @@ class SecureConfig:
         logger.info(f"Updated API key for {service}")
     
     def get_config(self, key: str, default: Any = None) -> Any:
-        """Get a configuration value.
+        """Get a configuration value with environment variable fallback.
         
         Parameters
         ----------
@@ -144,15 +144,26 @@ class SecureConfig:
         Any
             Configuration value
         """
+        # Check environment variable first
+        env_var = key.upper().replace('.', '_')
+        env_val = os.getenv(env_var)
+        if env_val is not None:
+            logger.debug(f"Using {key} from environment variable {env_var}")
+            return env_val
+
         keys = key.split('.')
         value = self._config_data
-        
+
         try:
             for k in keys:
                 value = value[k]
             return value
         except (KeyError, TypeError):
             return default
+
+    def get_flask_config(self) -> str:
+        """Return the Flask configuration setting."""
+        return os.getenv("FLASK_CONFIG", self._config_data.get("flask_config", "production"))
     
     def set_config(self, key: str, value: Any) -> None:
         """Set a configuration value.
@@ -224,3 +235,8 @@ def get_config() -> SecureConfig:
 def get_api_key(service: str) -> Optional[str]:
     """Convenience function to get an API key."""
     return get_config().get_api_key(service)
+
+
+def get_flask_config() -> str:
+    """Convenience function to get the Flask configuration setting."""
+    return get_config().get_flask_config()


### PR DESCRIPTION
## Summary
- add environment variable fallback to configuration retrieval and expose `get_flask_config`
- document required environment variables and provide `.env.example`

## Testing
- `python run_tests.py unit`

------
https://chatgpt.com/codex/tasks/task_e_68a675b10b848326b544725207a9542f