### PR TITLE
Add logging, health check, and monitoring

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,8 +1,15 @@
 """Application factory for the economy charts Flask application."""
 
 from __future__ import annotations
+import logging
+import sys
+from logging.handlers import RotatingFileHandler
+from pathlib import Path
+
 from flask import Flask
-from app.config.secrets import SecureConfig
+from prometheus_flask_exporter import PrometheusMetrics
+
+from app.config.secrets import SecureConfig, get_config
 from app.dash.charts import create_dash_app
 
 
@@ -16,6 +23,8 @@ def create_app(config_class=SecureConfig) -> Flask:
 
     app = Flask(__name__)
     app.config.from_object(config_class)
+    _configure_logging()
+    PrometheusMetrics(app)
 
     # Initialize Dash app
     dash_app = create_dash_app()
@@ -27,3 +36,32 @@ def create_app(config_class=SecureConfig) -> Flask:
     init_routes(app)
 
     return app
+
+
+def _configure_logging() -> None:
+    """Configure application logging.
+
+    Uses RotatingFileHandler if a log file is specified in the configuration;
+    otherwise logs to standard output.
+    """
+
+    config = get_config()
+    level_name = config.get_config("logging.level", "INFO").upper()
+    log_file = config.get_config("logging.file")
+
+    root_logger = logging.getLogger()
+    root_logger.handlers.clear()
+    root_logger.setLevel(getattr(logging, level_name, logging.INFO))
+
+    if log_file:
+        log_path = Path(log_file)
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        handler = RotatingFileHandler(log_path, maxBytes=1_000_000, backupCount=5)
+    else:
+        handler = logging.StreamHandler(sys.stdout)
+
+    formatter = logging.Formatter(
+        "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+    )
+    handler.setFormatter(formatter)
+    root_logger.addHandler(handler)

--- a/app/routes.py
+++ b/app/routes.py
@@ -35,5 +35,9 @@ def init_routes(app):
     def contact():
         return render_template("contact.html", active_page="contact")
 
+    @app.route("/health")
+    def health():
+        return {"status": "ok"}, 200
+
     # Note: Dash routes are automatically handled by the Dash app integration
     # The /dash/ route is managed by the Dash application itself

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,3 +9,17 @@ services:
       - redis
   redis:
     image: redis:7-alpine
+  prometheus:
+    image: prom/prometheus:latest
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml
+    ports:
+      - "9090:9090"
+    depends_on:
+      - web
+  grafana:
+    image: grafana/grafana:latest
+    ports:
+      - "3000:3000"
+    depends_on:
+      - prometheus

--- a/prometheus.yml
+++ b/prometheus.yml
@@ -1,0 +1,7 @@
+global:
+  scrape_interval: 15s
+
+scrape_configs:
+  - job_name: 'flask_app'
+    static_configs:
+      - targets: ['web:8000']

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ plotly>=5.16
 fredapi>=0.5.0
 pytest>=7.0
 pytest-mock>=3.10
+prometheus-flask-exporter>=0.23


### PR DESCRIPTION
## Summary
- configure Python logging with rotating file handler or stdout fallback
- expose `/health` route for uptime checks
- integrate Prometheus metrics and add Prometheus/Grafana services

## Testing
- `python run_tests.py unit`


------
https://chatgpt.com/codex/tasks/task_e_68a675b0f3ac8326a6af548f11554ad4