### PR TITLE
Add backup script and restore documentation

### DIFF
--- a/BACKUP_RESTORE.md
+++ b/BACKUP_RESTORE.md
@@ -1,0 +1,52 @@
+# Backup and Restore Guide
+
+This project includes a simple script to back up configuration files and any
+persistent data/cache.
+
+## Scheduled Backups
+
+1. Adjust the directories to back up by setting the `BACKUP_TARGETS`
+   environment variable (defaults to `app/config app/data/cache`).
+2. Set remote storage credentials:
+   - `S3_BUCKET` for uploading to Amazon S3, **or**
+   - `REMOTE_HOST` and optional `REMOTE_PATH` for `scp`/`ssh` targets.
+3. Schedule the backup script with `cron`:
+
+   ```cron
+   0 3 * * * /path/to/repo/scripts/backup.sh >> /var/log/dataprofusion_backup.log 2>&1
+   ```
+
+   The above example runs the backup every night at 3 AM.
+
+## Restore Procedure
+
+1. Retrieve the desired archive from your remote storage, e.g.:
+
+   ```bash
+   aws s3 cp s3://$S3_BUCKET/dataprofusion-<timestamp>.tar.gz .
+   # or
+   scp user@host:/path/dataprofusion-<timestamp>.tar.gz .
+   ```
+2. Extract the archive in the project directory:
+
+   ```bash
+   tar xzf dataprofusion-<timestamp>.tar.gz -C /path/to/repo
+   ```
+3. Restart services that rely on the restored files, if necessary.
+
+## Testing Restores
+
+Regularly verify that backups can be restored by performing a test restore to a
+separate environment:
+
+1. Run the backup script manually and restore the archive to a temporary
+   location.
+2. Execute the unit tests to confirm the application still functions:
+
+   ```bash
+   python run_tests.py unit
+   ```
+3. Discard the temporary environment after verification.
+
+Testing restores periodically ensures the backup process remains reliable and
+that the documentation stays current.

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -euo pipefail
+
+# Directories to include in the backup. Override with BACKUP_TARGETS env var.
+TARGETS=${BACKUP_TARGETS:-"app/config app/data/cache"}
+
+TIMESTAMP=$(date +"%Y%m%d%H%M%S")
+ARCHIVE="dataprofusion-${TIMESTAMP}.tar.gz"
+
+# Create archive; ignore directories that may not exist.
+tar czf "$ARCHIVE" $TARGETS --ignore-failed-read
+
+# Upload to remote storage when configured.
+if [[ -n "${S3_BUCKET:-}" ]]; then
+    aws s3 cp "$ARCHIVE" "s3://${S3_BUCKET}/"
+    rm "$ARCHIVE"
+elif [[ -n "${REMOTE_HOST:-}" ]]; then
+    scp "$ARCHIVE" "${REMOTE_HOST}:${REMOTE_PATH:-.}/"
+    rm "$ARCHIVE"
+else
+    echo "Backup created at $PWD/$ARCHIVE"
+fi


### PR DESCRIPTION
## Summary
- add `scripts/backup.sh` for archiving configuration and cache files and pushing to remote storage
- document backup scheduling and restore procedures in `BACKUP_RESTORE.md`

## Testing
- `python run_tests.py unit`


------
https://chatgpt.com/codex/tasks/task_e_68a69d9595d083268c6e7e7a88cc74bd