### PR TITLE
Add CI workflow for linting and tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  lint-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.x"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install black flake8
+      - name: Lint and format
+        run: |
+          set -e
+          black --check .
+          flake8 .
+      - name: Run tests
+        run: python run_tests.py all


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow running black, flake8, and tests

## Testing
- `python run_tests.py all`
- `black --check .` *(fails: would reformat files)*
- `flake8 .` *(fails: various lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a69d92c7b883268f81ac92549b72a4