### PR TITLE
ci: add deployment workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,52 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+    tags: [ '*' ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Run tests
+        run: |
+          pytest
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: test
+    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/'))
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up SSH
+        uses: webfactory/ssh-agent@v0.9.0
+        with:
+          ssh-private-key: ${{ secrets.DEPLOY_KEY }}
+      - name: Deploy via rsync and restart service
+        env:
+          SSH_HOST: ${{ secrets.SSH_HOST }}
+          SSH_USER: ${{ secrets.SSH_USER }}
+        run: |
+          set -e
+          REMOTE_RELEASE_DIR=/srv/dataprofusion/releases/${GITHUB_SHA}
+          ssh -o StrictHostKeyChecking=no $SSH_USER@$SSH_HOST "mkdir -p $REMOTE_RELEASE_DIR"
+          rsync -az --delete --exclude '.git' ./ $SSH_USER@$SSH_HOST:$REMOTE_RELEASE_DIR/
+          ssh -o StrictHostKeyChecking=no $SSH_USER@$SSH_HOST <<EOF2
+            set -e
+            ln -sfn $REMOTE_RELEASE_DIR /srv/dataprofusion
+            sudo systemctl restart dataprofusion
+            ls -1dt /srv/dataprofusion/releases/* | tail -n +6 | xargs rm -rf || true
+          EOF2
+


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow
- deploy to server via SSH on main or tags and retain previous releases for rollback

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a69d93aa648326820a66a3c0835433