### PR TITLE
style: unify tiles and footer colors

### DIFF
--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -167,9 +167,9 @@
             flex-direction: column;
             align-items: center;
             text-decoration: none;
-            background: rgba(255, 255, 255, 0.1);
+            background: rgba(0, 0, 0, 0.7);
             backdrop-filter: blur(10px);
-            border: 2px solid rgba(255, 255, 255, 0.2);
+            border: 2px solid #228B22;
             border-radius: 15px;
             padding: 2rem;
             transition: all 0.3s ease;
@@ -357,6 +357,11 @@
         .footer-nav {
             display: flex;
             justify-content: center;
+            background: rgba(0, 0, 0, 0.7);
+            backdrop-filter: blur(10px);
+            border: 2px solid rgba(255, 255, 255, 0.2);
+            border-radius: 15px;
+            padding: 0.5rem 1rem;
         }
 
         .footer-nav a {


### PR DESCRIPTION
## Summary
- make home page tiles match dark hover color while keeping hover animation
- style footer navigation with same translucent dark background as navbar

## Testing
- `python run_tests.py unit`

------
https://chatgpt.com/codex/tasks/task_e_68b11a93bd448326a25cdab512144f63