### PR TITLE
Add starter privacy and terms pages with global footer

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -35,6 +35,14 @@ def init_routes(app):
     def contact():
         return render_template("contact.html", active_page="contact")
 
+    @app.route("/privacy")
+    def privacy():
+        return render_template("privacy.html", active_page=None)
+
+    @app.route("/terms")
+    def terms():
+        return render_template("terms.html", active_page=None)
+
     @app.route("/health")
     def health():
         return {"status": "ok"}, 200

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -550,8 +550,8 @@
             </div>
         </div>
         <nav class="footer-nav">
-            <a href="#privacy">Privacy</a>
-            <a href="#terms">Terms</a>
+            <a href="{{ url_for('privacy') }}">Privacy</a>
+            <a href="{{ url_for('terms') }}">Terms</a>
         </nav>
     </footer>
 

--- a/app/templates/layout.html
+++ b/app/templates/layout.html
@@ -17,6 +17,23 @@
       body {
         margin: 40px;
       }
+      .footer {
+        margin-top: 2rem;
+        padding: 1rem 0;
+        text-align: center;
+        border-top: 1px solid rgba(255, 255, 255, 0.2);
+      }
+      .footer a {
+        margin: 0 0.5rem;
+        color: #39FF14;
+        text-decoration: none;
+        font-weight: bold;
+      }
+      .footer a:hover {
+        color: #00ff88;
+        text-decoration: underline;
+        text-decoration-color: #00ff88;
+      }
     </style>
   </head>
   <body>
@@ -33,5 +50,11 @@
       </div>
     </nav>
     {% block content %}{% endblock %}
+    <footer class="footer">
+      <nav class="footer-nav">
+        <a href="{{ url_for('privacy') }}">Privacy</a>
+        <a href="{{ url_for('terms') }}">Terms</a>
+      </nav>
+    </footer>
   </body>
 </html>

--- a/app/templates/privacy.html
+++ b/app/templates/privacy.html
@@ -1,0 +1,7 @@
+{% extends "layout.html" %}
+{% block content %}
+<div class="main-content">
+    <h1>Privacy Policy</h1>
+    <p>This is a starter privacy policy page. Update this content with your site's actual privacy practices.</p>
+</div>
+{% endblock %}

--- a/app/templates/terms.html
+++ b/app/templates/terms.html
@@ -1,0 +1,7 @@
+{% extends "layout.html" %}
+{% block content %}
+<div class="main-content">
+    <h1>Terms of Service</h1>
+    <p>This is a starter terms of service page. Replace this with your site's actual terms and conditions.</p>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add starter privacy and terms templates
- expose `/privacy` and `/terms` routes and links in new site-wide footer
- update index footer links to use new routes

## Testing
- `python run_tests.py unit`


------
https://chatgpt.com/codex/tasks/task_e_68bbac6ba02883268b3c943d5a16f992